### PR TITLE
feat : 게시판 주제 생성, 수정, 삭제, 조회 기능 구현

### DIFF
--- a/src/main/java/com/onlinecommunity/controller/TopicController.java
+++ b/src/main/java/com/onlinecommunity/controller/TopicController.java
@@ -1,0 +1,53 @@
+package com.onlinecommunity.controller;
+
+import com.onlinecommunity.domain.topic.ForDeleteTopic;
+import com.onlinecommunity.domain.topic.ForRegisterTopic;
+import com.onlinecommunity.domain.topic.ForUpdateTopic;
+import com.onlinecommunity.service.TopicService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/topic")
+@RequiredArgsConstructor
+public class TopicController {
+    private final TopicService topicService;
+
+    // 주제 추가 (관리자만 가능)
+    @PostMapping("")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> registerTopic(@Validated @RequestBody ForRegisterTopic request) {
+        var result = this.topicService.registerTopic(request);
+        return ResponseEntity.ok(result);
+    }
+
+    // 주제 수정 (관리자만 가능)
+    @PutMapping("")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> updateTopic(@Validated @RequestBody ForUpdateTopic request) {
+        var result = this.topicService.updateTopic(request);
+        return ResponseEntity.ok(result);
+    }
+
+    // 주제 삭제 (관리자만 가능)
+    @DeleteMapping("")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> deleteTopic(@Validated @RequestBody ForDeleteTopic request) {
+        var result = this.topicService.deleteTopic(request);
+        return ResponseEntity.ok(result);
+    }
+
+
+    // 주제 조회, 이름순으로 출력, keyword로 검색시 keyword로 시작하는 주제들만 조회 가능
+    @GetMapping("/list")
+    public ResponseEntity<?> getTopics(Pageable pageable, @RequestParam(required = false) String keyword) {
+        var result = this.topicService.getTopics(pageable, keyword);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/onlinecommunity/domain/topic/ForDeleteTopic.java
+++ b/src/main/java/com/onlinecommunity/domain/topic/ForDeleteTopic.java
@@ -1,0 +1,10 @@
+package com.onlinecommunity.domain.topic;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Data;
+
+@Data
+public class ForDeleteTopic {
+    @PositiveOrZero
+    private int id;
+}

--- a/src/main/java/com/onlinecommunity/domain/topic/ForRegisterTopic.java
+++ b/src/main/java/com/onlinecommunity/domain/topic/ForRegisterTopic.java
@@ -1,0 +1,20 @@
+package com.onlinecommunity.domain.topic;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ForRegisterTopic {
+    @NotBlank
+    @Size(min=2, max=20)
+    private String name;
+
+    public Topic toEntity(){
+        return Topic.builder().name(this.name)
+                .insertdate(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/onlinecommunity/domain/topic/ForUpdateTopic.java
+++ b/src/main/java/com/onlinecommunity/domain/topic/ForUpdateTopic.java
@@ -1,0 +1,17 @@
+package com.onlinecommunity.domain.topic;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class ForUpdateTopic {
+    @PositiveOrZero
+    private int id;
+
+    @NotBlank
+    @Size(min=2, max=20)
+    private String name;
+}

--- a/src/main/java/com/onlinecommunity/domain/topic/Topic.java
+++ b/src/main/java/com/onlinecommunity/domain/topic/Topic.java
@@ -1,0 +1,35 @@
+package com.onlinecommunity.domain.topic;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.onlinecommunity.domain.member.MemberRole;
+import com.onlinecommunity.domain.member.MemberStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Entity(name = "topic")
+@DynamicUpdate
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Topic {
+    // 고유번호
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    // 주제 이름
+    private String name;
+
+    // 생성날짜 (주제 생성 날짜를 의미)
+    private LocalDateTime insertdate;
+
+    // 이름 변경용 함수
+    public void changeName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/onlinecommunity/repository/MemberRepository.java
+++ b/src/main/java/com/onlinecommunity/repository/MemberRepository.java
@@ -12,11 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Integer> {
 
     Optional<Member> findBySignupid(String signupid);
 
-    // @Query(value="select m.id as id, m.signupid as signupid \n" +
-    //         " from com.onlinecommunity.domain.member.Member as m \n" +
-    //         " where m.signupid = ?1")
-    // Optional<Auth.IdInterface> findidBySignupid(String signupid);
-
     boolean existsBySignupid(String signupid);
 
     boolean existsByNickname(String nickname);

--- a/src/main/java/com/onlinecommunity/repository/TopicRepository.java
+++ b/src/main/java/com/onlinecommunity/repository/TopicRepository.java
@@ -1,0 +1,18 @@
+package com.onlinecommunity.repository;
+
+import com.onlinecommunity.domain.topic.Topic;
+import org.hibernate.query.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TopicRepository extends JpaRepository<Topic, Integer> {
+
+    boolean existsByName(String name);
+
+    Optional<Topic> findAllById(int id);
+
+    List<Topic> findAllByNameStartingWithOrderByNameAsc(Pageable pageable, String name);
+}

--- a/src/main/java/com/onlinecommunity/security/SecurityConfiguration.java
+++ b/src/main/java/com/onlinecommunity/security/SecurityConfiguration.java
@@ -34,7 +34,8 @@ public class SecurityConfiguration {
                         "/auth/signup_admin",
                         "/auth/signin",
                         "/auth/information",
-                        "/auth/delete"
+                        "/auth/delete",
+                        "topic/list"
                 ).permitAll().anyRequest().authenticated())
                 .addFilterBefore(this.authenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/onlinecommunity/service/TopicService.java
+++ b/src/main/java/com/onlinecommunity/service/TopicService.java
@@ -1,0 +1,64 @@
+package com.onlinecommunity.service;
+
+import com.onlinecommunity.domain.topic.ForDeleteTopic;
+import com.onlinecommunity.domain.topic.ForRegisterTopic;
+import com.onlinecommunity.domain.topic.ForUpdateTopic;
+import com.onlinecommunity.domain.topic.Topic;
+import com.onlinecommunity.repository.TopicRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class TopicService {
+
+    private final TopicRepository topicRepository;
+
+    // 이름을 검색하지 않았을 때 오류가 발생하지 않도록 null을 ""로 바꿔주는 함수
+    private String getKeyword(String keyword) {
+        return keyword == null ? "" : keyword;
+    }
+
+    public Topic registerTopic(ForRegisterTopic request) {
+        boolean exists = this.topicRepository.existsByName(request.getName());
+        if (exists) {
+            throw new RuntimeException("이미 존재하는 이름입니다. -> " + request.getName());
+        }
+
+        var result =topicRepository.save(request.toEntity());
+        return result;
+    }
+
+    public List<Topic> getTopics(Pageable pageable, String keyword) {
+        var result = topicRepository.findAllByNameStartingWithOrderByNameAsc(pageable, getKeyword(keyword));
+        return result;
+    }
+
+    @Transactional
+    public Topic updateTopic(ForUpdateTopic request) {
+        Topic topic = this.topicRepository.findAllById(request.getId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 주제 ID 입니다. -> " + request.getId()));
+
+        boolean exists = this.topicRepository.existsByName(request.getName());
+        if (exists) {
+            throw new RuntimeException("이미 존재하는 이름입니다. -> " + request.getName());
+        }
+
+        topic.changeName(request.getName());
+        return topic;
+    }
+
+    public String deleteTopic(ForDeleteTopic request) {
+        Topic topic = this.topicRepository.findAllById(request.getId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 주제 ID 입니다. -> " + request.getId()));
+
+        this.topicRepository.delete(topic);
+        return "Delete Complete!";
+    }
+}

--- a/src/test/http/forTest.http
+++ b/src/test/http/forTest.http
@@ -23,8 +23,8 @@ POST http://localhost:8085/auth/signin
 Content-Type: application/json
 
 {
-  "signupid": "user001",
-  "password": "abcd001!?"
+  "signupid": "admin001",
+  "password": "admin0101"
 }
 
 ### 현재 로그인중인 사용자 정보 가져오기 (비밀번호 같은 민감한 정보는 반환되지 않습니다.)
@@ -72,3 +72,34 @@ Content-Type: application/json
   "signupid": "uuuu999454554459",
   "password": "8888uuuu"
 }
+
+### 새로운 게시판 주제 생성 (관리자만 생성 가능, 이름 중복 불가능, 이름 길이 제한 : 2 이상 20 이하)
+POST http://localhost:8085/topic
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbjAwMSIsInJvbGVzIjpbIlJPTEVfQURNSU4iXSwiaWF0IjoxNzIwMTU3Mzg5LCJleHAiOjE3MjAxNjA5ODl9.tdQ7c89xL0q60Ucr8zdJXJDyiDv40xFkuaBoTYR9cUxzY5YW1GTOSVE7YjocCBTfxSCCVnUGnMlIQcyJXeWiPA
+Content-Type: application/json
+
+{
+  "name": "감자탕"
+}
+
+### 기존의 게시판 주제 이름 수정 (관리자만 수정 가능, 이름 중복 불가능, 이름 길이 제한 : 2 이상 20 이하)
+PUT http://localhost:8085/topic
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbjAwMSIsInJvbGVzIjpbIlJPTEVfQURNSU4iXSwiaWF0IjoxNzIwMjI1NTg5LCJleHAiOjE3MjAyMjkxODl9.WycBRt0eGUnPkCntikIsUf9-0HACinimK9-Vt-IGwVCE3ECaIqi80G4XnDEr_FvkMj3iYkYJM2SDb3rx8aUu6Q
+Content-Type: application/json
+
+{
+  "id": 6,
+  "name": "감자탕22"
+}
+
+### 기존의 게시판 삭제 (관리자만 삭제 가능, 삭제하면 해당 게시판의 모든 게시글들도 삭제가 됩니다.)
+DELETE http://localhost:8085/topic
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbjAwMSIsInJvbGVzIjpbIlJPTEVfQURNSU4iXSwiaWF0IjoxNzIwMTYyMTc3LCJleHAiOjE3MjAxNjU3Nzd9.qxfDsBdNx9lOwDYPu0A8bAXsgTuob06NxOmo_k9h4eIhMrjQigfTPEiY8QA2t-k3JA97TqanmyvpOkVCc1Bv9g
+Content-Type: application/json
+
+{
+  "id": 3
+}
+
+### 게시판 주제 조회 (이름 순으로 출력, keyword 항목을 추가하면 해당 키워드로 시작하는 주제들만 출력)
+GET http://localhost:8085/topic/list?size=10&page=0


### PR DESCRIPTION
### 개요
- 게시글 관련 기능들을 생성하기 전에 게시글들을 분류할 수 있는 게시판 주제에 대한 기능들을 먼저 추가해야 할 필요성을 느꼈습니다. 그래서 먼저 관리자가 주제를 생성, 수정, 삭제 할 수 있도록 만들고 현재 존재하는 주제를 조회할 수 있는 기능을 구현하였습니다.
<hr>

### 변경 사항

#### 파일
- DB에서 게시판 주제를 관리하는 테이블과 연동되는 Topic 클래스를 구현하였습니다.

- 주제 생성을 할 때 매개변수로 사용하기 위한 ForRegisterTopic  클래스를 구현하였습니다.

- 주제 수정을 할 때 매개변수로 사용하기 위한 ForUpdateTopic  클래스를 구현하였습니다.

- 주제 삭제를 할 때 매개변수로 사용하기 위한 ForDeleteTopic  클래스를 구현하였습니다.

- Jpa 방식으로 주제 테이블에서 값을 찾거나 변경, 제거할 수 있도록 TopicRepository라는 이름의 JpaRepository 인터페이스를 생성하였습니다.

- 게시판 주제와 관련된 api 함수들이 있는 TopicController 클래스와 해당 클래스에서 사용하는 메서드들이 모여있는 TopicService 클래스를 생성하였습니다.

- api 작동을 테스트하기 위해 forTest.http 파일의 내용을 수정하였습니다.

- 주제 조회 기능은 로그인을 하지 않고도 이용할 수 있도록 SecurityConfiguration 클래스의 내용을 수정하였습니다.

#### 기능
- 게시판 주제 추가 기능을 구현하였습니다. 주제 이름을 필요로 하며 유효한 길이 범위로 작성했을 때, 주제 이름이 서로 중복이 되지 않을 때 생성이 되도록 구현하였으며 관리자 권한이 있을 때 해당 기능을 사용 가능하도록 만들었습니다.

- 게시판 주제 수정 기능을 구현하였습니다. 주제 ID와 이름을 필요로 하며 생성 때와 마찬가지로 유효한 길이 범위로 작성했을 때, 주제 이름이 서로 중복이 되지 않을 때 수정이 되도록 구현하였으며 관리자 권한이 있을 때 해당 기능을 사용 가능하도록 만들었습니다.

- 게시판 주제 삭제 기능을 구현하였습니다. 주제 ID를 필요로 하며 관리자 권한이 있을 때 해당 기능을 사용 가능하도록 만들었습니다.

- 게시판 주제 조회 기능을 구현하였습니다. 가나다 순으로 출력이 되며 page, size 값을 입력해서 원하는 범위만큼 출력이 되도록 만들었습니다. 그리고 keyword 값을 입력시 해당 keyword로 시작하는 주제들만 출력이 되도록 만들었습니다.
<hr>

### 테스트 결과
- DB에 값이 새로 생성되고 변경, 제거되는 것을 확인하였습니다.

- 생성된 값들이 조건에 맞게 조회됨을 확인하였습니다.

- 예외처리가 원하는 형태로 작동하는 것을 확인하였습니다.
<hr>

### 향후 계획
- 이제 주제에 맞게 게시글을 작성할 수 있는 환경이 마련되었으니 원래 진행 예정이였던 게시글 관련 파일 생성 및 기능 구현을 시작할 예정입니다.